### PR TITLE
Registering the MessageCtrl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ UPPHUB_BEGIN
       "repository": "https://github.com/ismail-yilmaz/MessageCtrl.git",
       "status": "stable",
       "category": "widget",
-      "readme": "https://github.com/ismail-yilmaz/MessageCtrl/blob/master/README.md"
+      "readme": "https://github.com/ismail-yilmaz/MessageCtrl/blob/main/README.md"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ UPPHUB_BEGIN
       "repository": "https://github.com/ismail-yilmaz/MessageCtrl.git",
       "status": "stable",
       "category": "widget",
-      "readme": "https://github.com/ismail-yilmaz/MessageCtrl/blob/main/README.md"
+      "readme": "https://github.com/ismail-yilmaz/MessageCtrl/blob/master/README.md"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ UPPHUB_BEGIN
       "category": "scientific",
       "readme": "https://raw.githubusercontent.com/mirek-fidler/gdal/master/README.md"
     }
+    { "name": "MessageCtrl",
+      "packages": [ "MessageCtrl"],
+      "description": "A passive notifications widget for U++",
+      "repository": "https://github.com/ismail-yilmaz/MessageCtrl.git",
+      "status": "stable",
+      "category": "widget",
+      "readme": "https://github.com/ismail-yilmaz/MessageCtrl/blob/main/README.md"
+    }
   ]
 }
 UPPHUB_END

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ UPPHUB_BEGIN
       "status": "stable",
       "category": "scientific",
       "readme": "https://raw.githubusercontent.com/mirek-fidler/gdal/master/README.md"
-    }
+    },
     { "name": "MessageCtrl",
       "packages": [ "MessageCtrl"],
       "description": "A passive notifications widget for U++",


### PR DESCRIPTION
I am attempting to register the first package from `upp-components` repo. 

Notes:
1.  I tagged its category as "widget" but we should discuss in U++ forums how to categorize UppHub stuff and put some restrictions. 

2.  I think this registration process should be done via pull requests even for the maintainers, so that other maintainers can review it.
