### PR TITLE
Registering the terminal package.

### DIFF
--- a/nests.json
+++ b/nests.json
@@ -110,6 +110,17 @@
       "status": "stable",
       "category": "scientific",
       "readme": "https://raw.githubusercontent.com/ultimatepp/sundials/master/README.md"
+    }, 
+    {
+      "name": "TerminalCtrl",
+      "packages": [
+        "Terminal"
+      ],
+      "description": "A flexible and powerful terminal emulation widget and library for Ultimate++",
+      "repository": "https://github.com/ismail-yilmaz/Terminal.git",
+      "status": "rolling",
+      "category": "widget",
+      "readme": "https://raw.githubusercontent.com/ismail-yilmaz/Terminal/master/README.md"
     }
   ]
 }


### PR DESCRIPTION
I've validated the json, feel free to comment or change stuff.

P.s: While the package name is `TerminalCtrl` , directory name remains `Terminal`, because it contains components that can be used independently if required (e.g. the VTInStream, SixelRaster and PtyProcess).