### PR TITLE
PtyProcess package is added to TerminalCtrl

### DIFF
--- a/nests.json
+++ b/nests.json
@@ -192,7 +192,8 @@
     {
       "name": "TerminalCtrl",
       "packages": [
-        "Terminal"
+        "Terminal",
+        "PtyProcess"
       ],
       "description": "A flexible and powerful terminal emulation widget and library for U++",
       "repository": "https://github.com/ismail-yilmaz/Terminal.git",


### PR DESCRIPTION
Reason: Since we are still migrating to UppHub, I made a "course-correction" and take this opportunity to add PtyProcess to TerminalCtrl as a separate but related package.

PtyProcess code shouldn't be an integral part of the package since TerminalCtrl  can be compiled as a pure remote terminal, without requiring a local pty.

I'll announce this change in forums too, as it introduces a trivial breakage.

Please check.