### PR TITLE
StackCtrl added to the list.

### DIFF
--- a/nests.json
+++ b/nests.json
@@ -424,8 +424,8 @@
       ],
       "description": "A simple widget stacking container for U++ that displays only one ctrl at a time.",
       "repository": "https://github.com/ismail-yilmaz/StackCtrl.git",
-      "status": "stable",
-      "category": "CtrlLib",
+      "status": "experimental",
+      "category": "widget",
       "readme": "https://raw.githubusercontent.com/ismail-yilmaz/StackCtrl/main/README.md"
     }
   ]

--- a/nests.json
+++ b/nests.json
@@ -416,6 +416,17 @@
       "status": "experimental",
       "category": "draw",
       "readme": "https://raw.githubusercontent.com/ismail-yilmaz/EscPainter/main/README.md"
-    }    
+    },
+    {
+      "name": "StackCtrl",
+      "packages": [
+        "StackCtrl"
+      ],
+      "description": "A simple widget stacking container for U++ that displays only one ctrl at a time.",
+      "repository": "https://github.com/ismail-yilmaz/StackCtrl.git",
+      "status": "stable",
+      "category": "CtrlLib",
+      "readme": "https://raw.githubusercontent.com/ismail-yilmaz/StackCtrl/main/README.md"
+    }
   ]
 }


### PR DESCRIPTION
Adds a simple container ctrl to the UppHub that displays one child ctrl at a time. (similar to GTK::Stack or QT::QStackWidget)

Please check.