### PR TITLE
HtmlTools package added to the list.

### DIFF
--- a/nests.json
+++ b/nests.json
@@ -427,6 +427,17 @@
       "status": "experimental",
       "category": "widget",
       "readme": "https://raw.githubusercontent.com/ismail-yilmaz/StackCtrl/main/README.md"
+    },
+    {
+      "name": "HtmlTools",
+      "packages": [
+        "HtmlTools"
+      ],
+      "description": "Html parser, sanitizer, and prettifier tools. (A libtidy wrapper for U++)",
+      "repository": "https://github.com/ismail-yilmaz/HtmlTools.git",
+      "status": "experimental",
+      "category": "core",
+      "readme": "https://raw.githubusercontent.com/ismail-yilmaz/HtmlTools/main/README.md"
     }
   ]
 }


### PR DESCRIPTION
HtmlTools:  

- A [libtidy](https://www.html-tidy.org/developer/) wrapper for U++, encapsulating a powerful and highly optimized html parser, sanitizer, and prettifier. 
- Tested on Windows (CLANG), and Linux (GCC/CLANG)
- libtidy is statically linked on all environments.
- Comes with API doc and a simple example, ATM.

Please review.