### PR TITLE
Add CardDAV package to UppHub

### DIFF
--- a/nests.json
+++ b/nests.json
@@ -690,6 +690,17 @@
       "status": "stable",
       "category": "networking",
       "readme": "https://raw.githubusercontent.com/ismail-yilmaz/caldav/master/README.md"
+    },
+    {
+      "name": "CardDAV",
+      "packages": [
+    	"CardDAV"
+      ],
+      "description": "A lightweight, RFC 6352 compliant CardDAV client implementation for U++",
+      "repository": "https://github.com/ismail-yilmaz/carddav.git",
+      "status": "stable",
+      "category": "networking",
+      "readme": "https://raw.githubusercontent.com/ismail-yilmaz/carddav/master/README.md"
     }
   ]
 }


### PR DESCRIPTION
This PR is a follow up to #45 and adds CardDAV package to UppHub.

A lightweight, RFC 6352-compliant **CardDAV client** for U++.
Implements address book discovery, contact management, and vCard operations over HTTP/WebDAV protocol.

## Features

- **Full CardDAV coverage**: discovery, contact retrieval, creation, update, and deletion
- **Dual operation modes**: blocking and non-blocking
- **Built on WebDAV**: extends `WebDAVRequest`, inheriting all HTTP functionality, including SSL, authentication, and redirection
- **Simple U++ API**: clean, self-contained interface using familiar U++ conventions

## Supported Operations

- **Principal and home discovery**: `GetCurrentUserPrincipal`, `GetAddressBookHomeSet`
- **Address book collection discovery**: `GetAddressBooks`
- **Contact retrieval**: `GetContacts`, `GetContact`
- **Contact modification**: `AddContact`, `UpdateContact`, `DeleteContact`
- **Non-blocking variants**: all `Start*` methods correspond to blocking calls

## Examples

| Name               | Description                                                                         |
| ------------------ | ----------------------------------------------------------------------------------- |
| **CardDAVExample** | Demonstrates connecting to a CardDAV server, listing address books, and adding contacts |